### PR TITLE
Fixed scale when min and max are less than one

### DIFF
--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -10,6 +10,18 @@ export function clamp(val, min, max) {
   return val > max ? max : val < min ? min : val;
 }
 
+export function countDecimals(value, maxDecimals = 5) {
+  value = parseFloat(value.toFixed(maxDecimals));
+  if (Math.floor(value) === value) return 0;
+  const str = value.toString();
+  if (str.indexOf(".") === -1) return 0;
+  return str.split(".")[1].length;
+}
+
+export function roundDecimals(value, places) {
+  return parseFloat(parseFloat(value).toFixed(places));
+}
+
 export function deg2rad(angle) {
   return (angle * Math.PI * 2) / 360;
 }
@@ -24,12 +36,26 @@ export function getCoordFromDegrees(angle, radius, viewBox) {
 
 export function degreesToCompass(degrees) {
   // Normalize the angle to be within 0-360 degrees
-  const normalizedDegrees = (degrees % 360 + 360) % 360;
+  const normalizedDegrees = ((degrees % 360) + 360) % 360;
 
   // Define the compass points in order
   const compassPoints = [
-    "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
-    "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"
+    "N",
+    "NNE",
+    "NE",
+    "ENE",
+    "E",
+    "ESE",
+    "SE",
+    "SSE",
+    "S",
+    "SSW",
+    "SW",
+    "WSW",
+    "W",
+    "WNW",
+    "NW",
+    "NNW",
   ];
 
   // Calculate the index of the compass point

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -8,6 +8,7 @@ import { extendWithRenderMarker } from "./svg/renderMarker.js";
 import { extendWithRenderPointer } from "./svg/renderPointer.js";
 import { extendWithRenderIcon } from "./svg/renderIcon.js";
 import { extendWithRenderText } from "./svg/renderText.js";
+import { extendWithGetRoundedValue } from "./svg/getRoundedValue.js";
 
 import { ColourGradientScale } from "./helpers/ColourGradientScale.js";
 import {
@@ -35,6 +36,7 @@ export class RtRingSvg extends LitElement {
     extendWithRenderIcon(RtRingSvg);
     extendWithRenderDot(RtRingSvg);
     extendWithRenderCompass(RtRingSvg);
+    extendWithGetRoundedValue(RtRingSvg);
   }
 
   static get properties() {
@@ -190,9 +192,11 @@ export class RtRingSvg extends LitElement {
         if (this.ring_type === RT.CLOSED) {
           return nothing;
         }
-        const minText = Math.round(this.min, 0);
+        const minText = this.getRoundedValue(this.min, true);
         const maxText =
-          this.max - this.min < 0.01 ? "–" : Math.round(this.max, 0);
+          this.max - this.min < 0.01
+            ? "–"
+            : this.getRoundedValue(this.max, true);
 
         return svg`
           ${this.renderText(minText, "", POS.MIN)}
@@ -209,7 +213,7 @@ export class RtRingSvg extends LitElement {
         const value = [BE.RING_VALUE, BE.RING_VALUE_UNIT].includes(
           this.bottom_element
         )
-          ? this.value 
+          ? this.value
           : this.display_state.value;
 
         let unit = "";
@@ -315,11 +319,23 @@ export class RtRingSvg extends LitElement {
     }
     const iconHtml =
       this.middle_element === ME.ICON
-        ? this.renderIcon(POS.MIDDLE, this.display_state.stateObj, stateColourValue)
+        ? this.renderIcon(
+            POS.MIDDLE,
+            this.display_state.stateObj,
+            stateColourValue
+          )
         : this.top_element === TE.ICON
-        ? this.renderIcon(POS.TOP, this.display_state.stateObj, stateColourValue)
+        ? this.renderIcon(
+            POS.TOP,
+            this.display_state.stateObj,
+            stateColourValue
+          )
         : this.bottom_element === BE.ICON
-        ? this.renderIcon(POS.BOTTOM, this.display_state.stateObj, stateColourValue)
+        ? this.renderIcon(
+            POS.BOTTOM,
+            this.display_state.stateObj,
+            stateColourValue
+          )
         : nothing;
 
     // render the top, middle and bottom elements

--- a/src/svg/getRoundedValue.js
+++ b/src/svg/getRoundedValue.js
@@ -1,0 +1,29 @@
+import { countDecimals } from "../helpers/utilities";
+
+export function extendWithGetRoundedValue(RtRingSvg) {
+  RtRingSvg.prototype.getRoundedValue = function (value, trim = false) {
+    let decimals = Math.max(
+      Math.floor(this.min_sig_figs - Math.log10(Math.abs(value))),
+      0
+    );
+
+    // clamp decimals if needed
+    if (decimals > (this.max_decimals ?? 99)) {
+      decimals = this.max_decimals;
+    }
+
+    // Format
+    value = parseFloat(value).toFixed(decimals);
+
+    if (trim) {
+      value = parseFloat(value);
+      value = value.toFixed(countDecimals(value));
+    }
+    // Convert 0.0 to 0 if needed
+    if (parseFloat(value) === 0) {
+      value = "0";
+    }
+
+    return value;
+  };
+}

--- a/src/svg/renderText.js
+++ b/src/svg/renderText.js
@@ -62,26 +62,7 @@ export function extendWithRenderText(RtRingSvg) {
     // if value is a number, convert to text and set
     // the correct number of decimal places
     if (isNumber(value) && ![POS.MIN, POS.MAX].includes(position)) {
-      // let decimals;
-      // if (parseInt(value) === 0) {
-      //   decimals = this.min_sig_figs - 1;
-      // } else {
-      let decimals = Math.max(
-        Math.floor(this.min_sig_figs - Math.log10(Math.abs(value))),
-        0
-      );
-
-      // clamp decimals if needed
-      if (decimals > (this.max_decimals ?? 99)) {
-        decimals = this.max_decimals;
-      }
-
-      // Format
-      value = parseFloat(value).toFixed(decimals);
-      // Convert 0.0 to 0 if needed
-      if (parseFloat(value) === 0) {
-        value = "0";
-      }
+      value = this.getRoundedValue(value);
     }
 
     // adjust unit if required


### PR DESCRIPTION
For smaller `min` / `max` values, scale rendering sometimes added bootloads of extra decimal places, as flagged in #21. This seems to be related to javascript handling of float <-> string. 

Tweaked rendering of scale labels to prevent this from happening. 

Also reworked `min` and `max` rendering when `bottom_element: min_max` by applying `min_sig_figs` and `max_decimals` before rendering `min` and `max`. This means some people will notice a change in behaviour if `min` and `max` are non-integer. Previously, `min` and `max` were rounded to the nearest integer, now they will included the extra decimals.