### PR TITLE
Fix decimal point handling

### DIFF
--- a/src/localise/maths.js
+++ b/src/localise/maths.js
@@ -1,11 +1,19 @@
 export function getDecimalSeparator(locale) {
-  const parts = new Intl.NumberFormat(locale).formatToParts(1.1);
-  const dec = parts.find((p) => p.type === "decimal");
-  return dec ? dec.value : ".";
+  let dp = ".";
+  // figure out what the locale has to say
+  if (locale?.number_format === "language") {
+    // set according to the language
+    const parts = new Intl.NumberFormat(locale.language).formatToParts(1.1);
+    dp = parts.find((p) => p.type === "decimal").value;
+  } else if (locale?.number_format.endsWith("comma")) {
+    // custom number format
+    dp = ",";
+  }
+  return dp;
 }
 
-export function toLocaleFixed(value, decimals) {
+export function toLocaleFixed(value, decimals, locale) {
   const fixedValue = parseFloat(value).toFixed(decimals);
-  const dp = getDecimalSeparator();
+  const dp = getDecimalSeparator(locale);
   return fixedValue.replace(".", dp);
 }

--- a/src/svg/getRoundedValue.js
+++ b/src/svg/getRoundedValue.js
@@ -37,7 +37,7 @@ export function extendWithGetRoundedValue(RtRingSvg) {
     }
     
     // Format using locale-aware formatting (respecting '.' or ',' as needed)
-    const formatted = toLocaleFixed(value, decimals);
+    const formatted = toLocaleFixed(value, decimals, this.hass.locale);
 
     return formatted;
   };

--- a/src/svg/renderScale.js
+++ b/src/svg/renderScale.js
@@ -152,7 +152,7 @@ export function extendWithRenderScale(RtRingSvg) {
       const p3 = getCoordFromDegrees(degrees, labelRadius, VIEW_BOX);
 
       const fontSize = this.ring_size === 1 ? width * 2.5 : width * 1.15;
-      const dp = getDecimalSeparator();
+      const dp = getDecimalSeparator(this.hass.locale);
       const localeValue = value.replace(".", dp);
 
       return svg`

--- a/src/svg/renderText.js
+++ b/src/svg/renderText.js
@@ -6,12 +6,14 @@ import { getDecimalSeparator } from "../localise/maths";
 // export function renderText(cfg, value, unit, position) {
 export function extendWithRenderText(RtRingSvg) {
   RtRingSvg.prototype.renderText = function (value, unit, position) {
+    const self = this; // Capture the instance context
+
     function scaleFontSize(
       unit = "",
       unitScale = 1.0,
       maxLengthForScaling = 6
     ) {
-      const dp = getDecimalSeparator();
+      const dp = getDecimalSeparator(self.hass.locale);
       const valueLength =
         value.length -
         (value.includes(dp) ? 0.7 : 0) -


### PR DESCRIPTION
As noted in [#51](https://github.com/neponn/ring-tile-card/issues/51), and highlighted by @luxia in [the forums](https://community.home-assistant.io/t/ring-tile-card-visualise-your-sensor-data/899257/184), decimal point handling is not always consistent. This PR changes locale detection to use the configuration set in HA for the user, rather than the browser.