### PR TITLE
Add support for KNX icons

### DIFF
--- a/src/svg/renderIcon.js
+++ b/src/svg/renderIcon.js
@@ -84,13 +84,15 @@ export function extendWithRenderIcon(RtRingSvg) {
           const svg = haSvgIcon?.shadowRoot?.querySelector("svg");
           const path = svg?.querySelector("path");
           if (path) {
-            const vbSize =
-              svg.getAttribute("viewBox")?.split(" ")[3] || MDI_ICON_SIZE;
+            const viewBox = svg.getAttribute("viewBox");
+            const [x, y, width, height] = viewBox
+              ? viewBox.split(" ").map(Number)
+              : [0, 0, MDI_ICON_SIZE, MDI_ICON_SIZE];
             const d = path.getAttribute("d");
 
             // Cache the result for this icon + card-mod state so we don't
             // repeatedly re-extract while the values are unchanged.
-            const res = { d, vbSize };
+            const res = { d, x, y, width, height };
             try {
               this._iconSvgCache[cacheKey] = res;
             } catch (e) {
@@ -101,7 +103,7 @@ export function extendWithRenderIcon(RtRingSvg) {
             resolve(res);
           } else if (attempts >= maxAttempts) {
             clearInterval(interval);
-            resolve({ d: null, vbSize: null }); // Not found
+            resolve({ d: null, x: 0, y: 0, width: MDI_ICON_SIZE, height: MDI_ICON_SIZE }); // Not found
           }
           attempts++;
         }, 50);
@@ -162,15 +164,16 @@ export function extendWithRenderIcon(RtRingSvg) {
 
     const iconSvg = await getIconSvg.call(this, this.icon, this.hass);
 
-    scale *= MDI_ICON_SIZE / parseFloat(iconSvg.vbSize);
-    const iconTranslate = VIEW_BOX / 2 - (iconSvg.vbSize / 2) * scale;
+    scale *= MDI_ICON_SIZE / iconSvg.width;
+    const iconTranslateX = VIEW_BOX / 2 - (iconSvg.width / 2) * scale - iconSvg.x * scale;
+    const iconTranslateY = VIEW_BOX / 2 - (iconSvg.height / 2) * scale - iconSvg.y * scale + translateDown;
 
     return svg`
       <path 
         d=${iconSvg.d}
         fill=${stateColour || baseColour}
         transform=
-          "translate(${iconTranslate}, ${iconTranslate + translateDown})
+          "translate(${iconTranslateX}, ${iconTranslateY})
           scale(${scale}, ${scale})" 
       />`;
   };


### PR DESCRIPTION
As noted in [the forums](https://community.home-assistant.io/t/ring-tile-card-visualise-your-sensor-data/899257/196), the [KNX](https://github.com/mampfes/ha-knx-uf-iconset) icons don't render properly. This is because these icons use an obscure viewBox definition (the origin is not [0,0]). This PR makes viewBox handling more flexible to handle cases like the KNX icons.