### PR TITLE
Add animations

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -75,6 +75,7 @@ Important to note that the `tweaks` method only supports static styling; if you 
 | `--rt-scale-text-opacity` | `rt-scale-text-opacity` | Text opacity used for scale labels | `0`-`1` | `0.5` |
 | `--rt-font-family` | `rt-font-family` | Override the font used to render the ring (does not apply to info area) | Font name | Geist |
 | `--rt-ring-svg-size` | `rt-ring-svg-size` | Override the overall size of the ring enabling arbitrary scaling. **Caution!** may cause unappealling results! | Size literal (eg `53px`) | Scales with `ring_size` |
+| `--rt-transition` | `rt-transition` | Override the default transition coding used to animate ring changes | CSS code | `0.75s ease-in-out` |
 | `--rt-indicated-colour` | N/A | Provides access to the currently indicated colour. Use to "colourise" other elements to reflect the current state of the ring. *Not settable* | CSS colour code | |
 | N/A | `transparent_tile` | No background and no border | Boolean | `False` |
 | N/A | `tile_rows` | Customise the total height of the `ring-tile` card | `1.0`-`6.0`, card layout row units | `ring_size` row units |

--- a/src/const.js
+++ b/src/const.js
@@ -93,5 +93,3 @@ export const US_SPELLINGS = [
   { US: "marker2_color", AU: "marker2_colour" },
   { US: "colorize_icon", AU: "colourise_icon" },
 ];
-
-export const TRANSITION = "0.75s ease-in-out";

--- a/src/const.js
+++ b/src/const.js
@@ -93,3 +93,5 @@ export const US_SPELLINGS = [
   { US: "marker2_color", AU: "marker2_colour" },
   { US: "colorize_icon", AU: "colourise_icon" },
 ];
+
+export const TRANSITION = "0.5s ease-in-out";

--- a/src/const.js
+++ b/src/const.js
@@ -94,4 +94,4 @@ export const US_SPELLINGS = [
   { US: "colorize_icon", AU: "colourise_icon" },
 ];
 
-export const TRANSITION = "0.5s ease-in-out";
+export const TRANSITION = "0.75s ease-in-out";

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -67,3 +67,29 @@ export function degreesToCompass(degrees) {
   // Return the corresponding compass point
   return compassPoints[index];
 }
+
+export function browserVersion() {
+  const ua = navigator.userAgent;
+  let name = "Unknown",
+    version = "Unknown";
+
+  if (/edg/i.test(ua)) {
+    name = "Edge";
+    version = ua.match(/edg\/([\d.]+)/i)?.[1];
+  } else if (/chrome|crios/i.test(ua) && !/opr|opera|chromium|edg/i.test(ua)) {
+    name = "Chrome";
+    version = ua.match(/chrome\/([\d.]+)/i)?.[1];
+  } else if (/firefox|fxios/i.test(ua)) {
+    name = "Firefox";
+    version = ua.match(/firefox\/([\d.]+)/i)?.[1];
+  } else if (/io.robbie.homeassistant/i.test(ua) && /like safari/i.test(ua)) {
+    name = "HA";
+    const versionMatch = ua.match(/\s(\w+OS)\s([\d.]+)/i);
+    name += ` ${versionMatch?.[1]};`;
+    version = versionMatch?.[2];
+  } else if (/safari/i.test(ua) && !/chrome|crios|edg|chromium/i.test(ua)) {
+    name = "Safari";
+    version = ua.match(/version\/([\d.]+)/i)?.[1];
+  }
+  return { name, version };
+}

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -28,6 +28,7 @@ import { clamp, degreesToCompass, isNumber } from "./helpers/utilities.js";
 export class RtRingSvg extends LitElement {
   _iconSvgCache = {};
   _iconSvg = nothing;
+  _updateHandlers = [];
 
   constructor(...args) {
     super(...args);
@@ -41,6 +42,8 @@ export class RtRingSvg extends LitElement {
     extendWithRenderDot(RtRingSvg);
     extendWithRenderCompass(RtRingSvg);
     extendWithGetRoundedValue(RtRingSvg);
+
+    this._updateHandlers.push(this.renderRingsUpdateHandler);
   }
 
   static get properties() {
@@ -296,6 +299,9 @@ export class RtRingSvg extends LitElement {
 
       this.requestUpdate();
     }
+    this._updateHandlers.forEach((handler) => {
+      handler(changedProps, this);
+    });
   }
 
   render() {
@@ -433,7 +439,7 @@ export class RtRingSvg extends LitElement {
         ${scale}
         <g
           class="indicators"
-          transform="rotate(${this.ring_type === RT.CLOSED ? 180: 0} 
+          transform="rotate(${this.ring_type === RT.CLOSED ? 180 : 0} 
             ${MID_BOX} ${MID_BOX})"
         >
           ${indicatorBottom.object} ${marker2.object} ${marker.object}

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -457,6 +457,7 @@ export class RtRingSvg extends LitElement {
       position: relative;
       vertical-align: middle;
       fill: var(--icon-primary-color, currentcolor);
+      --rt-transition: 0.75s ease-in-out;
     }
     svg {
       width: 100%;
@@ -527,6 +528,17 @@ export class RtRingSvg extends LitElement {
     }
     .pointer-centre {
       fill: #444444;
+    }
+    .indicator,
+    .marker {
+      transition: transform var(--rt-transition);
+    }
+    .dot {
+      transition: fill var(--rt-transition);
+    }
+    .solid-ring-animated {
+      transition: stroke-dasharray var(--rt-transition),
+        stroke var(--rt-transition);
     }
   `;
 }

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -505,5 +505,14 @@ export class RtRingSvg extends LitElement {
       transition: stroke-dasharray var(--rt-transition),
         stroke var(--rt-transition);
     }
+    @media (prefers-reduced-motion: reduce) {
+      .indicator,
+      .marker,
+      .dot,
+      .solid-ring-animated {
+        animation: none;
+        transition: none;
+      }
+    }
   `;
 }

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -44,6 +44,7 @@ export class RtRingSvg extends LitElement {
     extendWithGetRoundedValue(RtRingSvg);
 
     this._updateHandlers.push(this.renderRingsUpdateHandler);
+    this._updateHandlers.push(this.renderIconReady);
   }
 
   static get properties() {
@@ -263,42 +264,6 @@ export class RtRingSvg extends LitElement {
   }
 
   async updated(changedProps) {
-    // Check if icon or relevant state changed
-    if (
-      changedProps.has("icon") ||
-      changedProps.has("display_state") ||
-      changedProps.has("middle_element") ||
-      changedProps.has("top_element") ||
-      changedProps.has("bottom_element")
-    ) {
-      // Only fetch if needed
-      let stateColourValue;
-      if (this.colourise_icon) {
-        stateColourValue = this.state.value;
-      }
-      this._iconSvg =
-        this.middle_element === ME.ICON
-          ? await this.renderIcon(
-              POS.MIDDLE,
-              this.display_state.stateObj,
-              stateColourValue
-            )
-          : this.top_element === TE.ICON
-          ? await this.renderIcon(
-              POS.TOP,
-              this.display_state.stateObj,
-              stateColourValue
-            )
-          : this.bottom_element === BE.ICON
-          ? await this.renderIcon(
-              POS.BOTTOM,
-              this.display_state.stateObj,
-              stateColourValue
-            )
-          : nothing;
-
-      this.requestUpdate();
-    }
     this._updateHandlers.forEach((handler) => {
       handler(changedProps, this);
     });

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -23,7 +23,12 @@ import {
   IND,
   MID_BOX,
 } from "./const.js";
-import { clamp, degreesToCompass, isNumber } from "./helpers/utilities.js";
+import {
+  browserVersion,
+  clamp,
+  degreesToCompass,
+  isNumber,
+} from "./helpers/utilities.js";
 
 export class RtRingSvg extends LitElement {
   _iconSvgCache = {};
@@ -414,6 +419,14 @@ export class RtRingSvg extends LitElement {
     `;
   }
 
+  static get _suppressTrickyTransitions() {
+    const bv = browserVersion();
+    return (
+      (bv.name === "Safari" && bv.version < 17) ||
+      (bv.name.startsWith("HA") && parseFloat(bv.version) < 17)
+    );
+  }
+
   static styles = css`
     :host {
       display: var(--ha-icon-display, inline-flex);
@@ -510,9 +523,15 @@ export class RtRingSvg extends LitElement {
       .marker,
       .dot,
       .solid-ring-animated {
-        animation: none;
         transition: none;
       }
     }
+    ${this._suppressTrickyTransitions
+      ? css`
+          .solid-ring-animated {
+            transition: none;
+          }
+        `
+      : css``}
   `;
 }

--- a/src/rt-ring-svg.js
+++ b/src/rt-ring-svg.js
@@ -332,7 +332,8 @@ export class RtRingSvg extends LitElement {
         ? this.renderMarker(
             this.marker_value,
             `var(--rt-marker-color, var(--rt-marker-colour, ${this.marker_colour}))`,
-            this.compass_marker
+            this.compass_marker,
+            1
           )
         : nothing;
     const marker2 =
@@ -340,7 +341,8 @@ export class RtRingSvg extends LitElement {
         ? this.renderMarker(
             this.marker2_value,
             `var(--rt-marker2-color, var(--rt-marker2-colour, ${this.marker2_colour}))`,
-            this.compass_marker2
+            this.compass_marker2,
+            2
           )
         : nothing;
 

--- a/src/svg/getRingPath.js
+++ b/src/svg/getRingPath.js
@@ -2,56 +2,16 @@ import { VIEW_BOX } from "../const";
 import { getCoordFromDegrees } from "../helpers/utilities";
 
 export function getRingPath(startAngle, endAngle, outerRadius, width) {
-  const innerRadius = outerRadius - width;
+  const radius = outerRadius - width / 2;
   const longPathFlag = Math.abs(endAngle - startAngle) > 180 ? 1 : 0;
-  const outerStart = getCoordFromDegrees(
-    startAngle,
-    outerRadius,
-    VIEW_BOX
-  ).join(" ");
-  const outerEnd = getCoordFromDegrees(endAngle, outerRadius, VIEW_BOX).join(
-    " "
-  );
-  const innerStart = getCoordFromDegrees(
-    endAngle,
-    innerRadius,
-    VIEW_BOX
-  ).join(" ");
-  const innerEnd = getCoordFromDegrees(
-    startAngle,
-    innerRadius,
-    VIEW_BOX
-  ).join(" ");
-  const commands = [];
-  commands.push(`M ${outerStart}`);
-  commands.push(
-    `A ${outerRadius} ${outerRadius} 0 ${longPathFlag} 1 ${outerEnd}`
-  );
-  commands.push(`A ${width / 2} ${width / 2} 0 0 1 ${innerStart}`);
-  commands.push(
-    `A ${innerRadius} ${innerRadius} 0 ${longPathFlag} 0 ${innerEnd}`
-  );
-  commands.push(`A ${width / 2} ${width / 2} 0 0 1 ${outerStart}`);
-  const segment = commands.join(" ");
-  return segment;
-}
 
-export function getRingPath2(startAngle, endAngle, outerRadius, width){
-  const radius = outerRadius-width/2;
-  const longPathFlag = Math.abs(endAngle - startAngle) > 180 ? 1 : 0;
-  const start = getCoordFromDegrees(
-    startAngle,
-    radius,
-    VIEW_BOX
-  ).join(" ");
-  const end = getCoordFromDegrees(endAngle, radius, VIEW_BOX).join(
-    " "
-  );
+  const start = getCoordFromDegrees(startAngle, radius, VIEW_BOX).join(" ");
+  const end = getCoordFromDegrees(endAngle, radius, VIEW_BOX).join(" ");
+
   const commands = [];
   commands.push(`M ${start}`);
-  commands.push(
-    `A ${radius} ${radius} 0 ${longPathFlag} 1 ${end}`
-  );
+  commands.push(`A ${radius} ${radius} 0 ${longPathFlag} 1 ${end}`);
   const segment = commands.join(" ");
+
   return segment;
 }

--- a/src/svg/getRingPath.js
+++ b/src/svg/getRingPath.js
@@ -35,3 +35,23 @@ export function getRingPath(startAngle, endAngle, outerRadius, width) {
   const segment = commands.join(" ");
   return segment;
 }
+
+export function getRingPath2(startAngle, endAngle, outerRadius, width){
+  const radius = outerRadius-width/2;
+  const longPathFlag = Math.abs(endAngle - startAngle) > 180 ? 1 : 0;
+  const start = getCoordFromDegrees(
+    startAngle,
+    radius,
+    VIEW_BOX
+  ).join(" ");
+  const end = getCoordFromDegrees(endAngle, radius, VIEW_BOX).join(
+    " "
+  );
+  const commands = [];
+  commands.push(`M ${start}`);
+  commands.push(
+    `A ${radius} ${radius} 0 ${longPathFlag} 1 ${end}`
+  );
+  const segment = commands.join(" ");
+  return segment;
+}

--- a/src/svg/renderDot.js
+++ b/src/svg/renderDot.js
@@ -23,22 +23,19 @@ export function extendWithRenderDot(RtRingSvg) {
       object: svg`
         <g class="indicator"
           style="transform: rotate(${degrees}deg); 
-            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-            transition: transform ${TRANSITION};"
+            transform-origin: ${MID_BOX}px ${MID_BOX}px;"
         >
           <circle 
             class="dot"
             cx=${dotCoord[0]} cy=${dotCoord[1]} 
             r=${dotRadius - dotOutline / 2}
-            style="fill: ${this._grad.getSolidColour(rawValue)};
-              transition: fill 0.5s ease-in-out;"
+            style="fill: ${this._grad.getSolidColour(rawValue)};"
           />
         </g>`,
       mask: svg`
         <g class="indicator"
           style="transform: rotate(${degrees}deg); 
-            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-            transition: transform ${TRANSITION};"
+            transform-origin: ${MID_BOX}px ${MID_BOX}px;"
         >
           <clipPath id="dot-clip">
             <path d=${ringClipSegment}/>

--- a/src/svg/renderDot.js
+++ b/src/svg/renderDot.js
@@ -1,5 +1,5 @@
 import { svg } from "lit";
-import { MID_BOX, TRANSITION, VIEW_BOX } from "../const";
+import { MID_BOX, VIEW_BOX } from "../const";
 import { getRingPath } from "./getRingPath";
 import { getCoordFromDegrees } from "../helpers/utilities";
 
@@ -37,14 +37,21 @@ export function extendWithRenderDot(RtRingSvg) {
           style="transform: rotate(${degrees}deg); 
             transform-origin: ${MID_BOX}px ${MID_BOX}px;"
         >
-          <clipPath id="dot-clip">
-            <path d=${ringClipSegment}/>
-          </clipPath>
+          <mask id="dot-mask">
+            <rect width=${VIEW_BOX} height=${VIEW_BOX} fill="black" />
+            <path d=${ringClipSegment} 
+              stroke-width=${width * 1.1}
+              stroke-opacity="1"
+              stroke-linecap="round"
+              fill="transparent" 
+              stroke="white" 
+            />
+          </mask>
           <circle
             class="dot"
             cx=${dotCoord[0]} cy=${dotCoord[1]} 
             r=${dotRadius + dotOutline / 2}
-            clip-path="url(#dot-clip)"
+            mask="url(#dot-mask)"
           />
         </g>
       `,

--- a/src/svg/renderDot.js
+++ b/src/svg/renderDot.js
@@ -1,5 +1,5 @@
 import { svg } from "lit";
-import { VIEW_BOX } from "../const";
+import { MID_BOX, TRANSITION, VIEW_BOX } from "../const";
 import { getRingPath } from "./getRingPath";
 import { getCoordFromDegrees } from "../helpers/utilities";
 
@@ -7,38 +7,49 @@ export function extendWithRenderDot(RtRingSvg) {
   RtRingSvg.prototype.renderDot = function (degrees, rawValue) {
     const width = this._ringWidth;
     const radius = this._outerRadius - width / 2;
-    const dotCoord = getCoordFromDegrees(degrees, radius, VIEW_BOX);
+    const dotCoord = getCoordFromDegrees(0, radius, VIEW_BOX);
     const dotOutline =
       width * [0.55, 0.4, 0.35, 0.35, 0.35, 0.35][this.ring_size - 1];
     const dotRadius = width / 2 + dotOutline * 0.7;
 
     const ringClipSegment = getRingPath(
-      degrees - 10,
-      degrees + 10,
+      -10,
+      10,
       this._outerRadius + width * 0.05,
       width * 1.1
     );
 
     return {
       object: svg`
-        <g class="indicator">
+        <g class="indicator"
+          style="transform: rotate(${degrees}deg); 
+            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+            transition: transform ${TRANSITION};"
+        >
           <circle 
             class="dot"
             cx=${dotCoord[0]} cy=${dotCoord[1]} 
             r=${dotRadius - dotOutline / 2}
-            fill=${this._grad.getSolidColour(rawValue)}
+            style="fill: ${this._grad.getSolidColour(rawValue)};
+              transition: fill 0.5s ease-in-out;"
           />
         </g>`,
       mask: svg`
-        <clipPath id="dot-clip">
-          <path d=${ringClipSegment}
+        <g class="indicator"
+          style="transform: rotate(${degrees}deg); 
+            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+            transition: transform ${TRANSITION};"
+        >
+          <clipPath id="dot-clip">
+            <path d=${ringClipSegment}/>
+          </clipPath>
+          <circle
+            class="dot"
+            cx=${dotCoord[0]} cy=${dotCoord[1]} 
+            r=${dotRadius + dotOutline / 2}
+            clip-path="url(#dot-clip)"
           />
-        </clipPath>
-        <circle 
-          cx=${dotCoord[0]} cy=${dotCoord[1]} 
-          r=${dotRadius + dotOutline / 2}
-          clip-path="url(#dot-clip)"
-        />      
+        </g>
       `,
     };
   };

--- a/src/svg/renderIcon.js
+++ b/src/svg/renderIcon.js
@@ -1,5 +1,5 @@
-import { svg } from "lit";
-import { BE, IND, MDI_ICON_SIZE, POS, RT, SCALE, VIEW_BOX } from "../const";
+import { nothing, svg } from "lit";
+import { BE, IND, MDI_ICON_SIZE, ME, POS, RT, SCALE, TE, VIEW_BOX } from "../const";
 import { isNumber } from "../helpers/utilities";
 
 export function extendWithRenderIcon(RtRingSvg) {
@@ -103,7 +103,13 @@ export function extendWithRenderIcon(RtRingSvg) {
             resolve(res);
           } else if (attempts >= maxAttempts) {
             clearInterval(interval);
-            resolve({ d: null, x: 0, y: 0, width: MDI_ICON_SIZE, height: MDI_ICON_SIZE }); // Not found
+            resolve({
+              d: null,
+              x: 0,
+              y: 0,
+              width: MDI_ICON_SIZE,
+              height: MDI_ICON_SIZE,
+            }); // Not found
           }
           attempts++;
         }, 50);
@@ -165,8 +171,13 @@ export function extendWithRenderIcon(RtRingSvg) {
     const iconSvg = await getIconSvg.call(this, this.icon, this.hass);
 
     scale *= MDI_ICON_SIZE / iconSvg.width;
-    const iconTranslateX = VIEW_BOX / 2 - (iconSvg.width / 2) * scale - iconSvg.x * scale;
-    const iconTranslateY = VIEW_BOX / 2 - (iconSvg.height / 2) * scale - iconSvg.y * scale + translateDown;
+    const iconTranslateX =
+      VIEW_BOX / 2 - (iconSvg.width / 2) * scale - iconSvg.x * scale;
+    const iconTranslateY =
+      VIEW_BOX / 2 -
+      (iconSvg.height / 2) * scale -
+      iconSvg.y * scale +
+      translateDown;
 
     return svg`
       <path 
@@ -176,5 +187,47 @@ export function extendWithRenderIcon(RtRingSvg) {
           "translate(${iconTranslateX}, ${iconTranslateY})
           scale(${scale}, ${scale})" 
       />`;
+  };
+
+  RtRingSvg.prototype.renderIconReady = async function (
+    changedProperties,
+    self
+  ) {
+    // Check if icon or relevant state changed
+    if (
+      changedProperties.has("icon") ||
+      changedProperties.has("display_state") ||
+      changedProperties.has("middle_element") ||
+      changedProperties.has("top_element") ||
+      changedProperties.has("bottom_element")
+    ) {
+      // Only fetch if needed
+      let stateColourValue;
+      if (self.colourise_icon) {
+        stateColourValue = self.state.value;
+      }
+      self._iconSvg =
+        self.middle_element === ME.ICON
+          ? await self.renderIcon(
+              POS.MIDDLE,
+              self.display_state.stateObj,
+              stateColourValue
+            )
+          : self.top_element === TE.ICON
+          ? await self.renderIcon(
+              POS.TOP,
+              self.display_state.stateObj,
+              stateColourValue
+            )
+          : self.bottom_element === BE.ICON
+          ? await self.renderIcon(
+              POS.BOTTOM,
+              self.display_state.stateObj,
+              stateColourValue
+            )
+          : nothing;
+
+      self.requestUpdate();
+    }
   };
 }

--- a/src/svg/renderIcon.js
+++ b/src/svg/renderIcon.js
@@ -1,5 +1,15 @@
 import { nothing, svg } from "lit";
-import { BE, IND, MDI_ICON_SIZE, ME, POS, RT, SCALE, TE, VIEW_BOX } from "../const";
+import {
+  BE,
+  IND,
+  MDI_ICON_SIZE,
+  ME,
+  POS,
+  RT,
+  SCALE,
+  TE,
+  VIEW_BOX,
+} from "../const";
 import { isNumber } from "../helpers/utilities";
 
 export function extendWithRenderIcon(RtRingSvg) {

--- a/src/svg/renderMarker.js
+++ b/src/svg/renderMarker.js
@@ -1,13 +1,17 @@
 import { svg } from "lit";
-import { CM, IND, MID_BOX, RT, VIEW_BOX } from "../const";
+import { CM, IND, MID_BOX, RT, TRANSITION, VIEW_BOX } from "../const";
 import { clamp, deg2rad, getCoordFromDegrees } from "../helpers/utilities";
 
 export function extendWithRenderMarker(RtRingSvg) {
   RtRingSvg.prototype.renderMarker = function (
     markerValue,
     markerColour,
-    compassMarker
+    compassMarker,
+    markerId
   ) {
+    // Initialize previous degrees tracking
+    this._previousMarkerDegrees = this._previousMarkerDegrees || {};
+
     const width = this._ringWidth;
 
     // set up config
@@ -15,15 +19,29 @@ export function extendWithRenderMarker(RtRingSvg) {
     let markerWidth;
     let strokeWidth;
     let className = "marker";
+    let turns;
 
     if (this.ring_type.startsWith(RT.COMPASS)) {
       // set up config for compass markers
       degrees = parseFloat(markerValue);
-      degrees = (degrees + 180) % 360;
+      degrees = degrees + 180;
       className = "marker compass";
+      turns = degrees / 360;
+
+      // Adjust degrees for shortest path animation using turns
+      const key = `compass_${markerId}`;
+      const prevTurns = this._previousMarkerDegrees[key];
+      if (prevTurns !== undefined) {
+        let delta = turns - prevTurns;
+        if (Math.abs(delta) > 0.5) {
+          turns += delta > 0 ? -1 : 1;
+        }
+      }
+      this._previousMarkerDegrees[key] = turns;
+
       if (compassMarker === CM.DOT) {
         markerWidth = width * 1.5;
-        strokeWidth = width / 5; //this.ring_size <= 2 ? width / 5 : width / 8;
+        strokeWidth = width / 5;
       } else {
         markerWidth = 2.3 * width;
         strokeWidth = 0;
@@ -36,6 +54,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         ((this._endDegrees - this._startDegrees) *
           (clampedMarkerState - this.min)) /
           (this.max - this.min);
+      turns = degrees / 360;
       markerWidth = (this.indicator === IND.DOT ? 1.2 : 1.5) * width;
       strokeWidth =
         this.indicator === IND.DOT
@@ -50,16 +69,20 @@ export function extendWithRenderMarker(RtRingSvg) {
       if (compassMarker === CM.DOT) {
         // dot compass marker
         return svg`
-        <g class=${className} transform="rotate(${degrees} ${MID_BOX} ${MID_BOX})">
-          <circle
-            cx=${MID_BOX}
-            cy=${VIEW_BOX - (width * 0.7) / 2}
-            r=${markerWidth / 2}
-            fill=${markerColour}
-            stroke="var(--card-background-color, white)"
-            stroke-width=${strokeWidth}
-          />
-        </g>`;
+          <g class=${className} 
+            style="transform: rotate(${turns}turn); 
+              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+              transition: transform ${TRANSITION};"
+          >
+            <circle
+              cx=${MID_BOX}
+              cy=${VIEW_BOX - (width * 0.7) / 2}
+              r=${markerWidth / 2}
+              fill=${markerColour}
+              stroke="var(--card-background-color, white)"
+              stroke-width=${strokeWidth}
+            />
+          </g>`;
       }
 
       // render normal markers
@@ -73,7 +96,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         commands.push(`M ${MID_BOX} ${VIEW_BOX + width / 3 + strokeWidth}`);
       } else {
         // otherwise, start the tip overlapped with the ring
-        commands.push(`M ${MID_BOX} ${VIEW_BOX - width / 3}`);
+        commands.push(`M ${MID_BOX} ${VIEW_BOX - width / 1.7}`);
       }
       // now plot up and to the right to draw the first side of the triangle
       commands.push(
@@ -99,8 +122,10 @@ export function extendWithRenderMarker(RtRingSvg) {
 
       return {
         object: svg`
-          <g class=${className} 
-            transform="rotate(${degrees} ${MID_BOX} ${MID_BOX})"
+          <g class=${className}
+            style="transform: rotate(${turns}turn); 
+              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+              transition: transform ${TRANSITION};"
           >
             <path
               d=${triangle}
@@ -110,7 +135,11 @@ export function extendWithRenderMarker(RtRingSvg) {
             />
           </g>`,
         mask: svg`
-          <g transform="rotate(${degrees} ${MID_BOX} ${MID_BOX})">
+          <g class=${className}
+            style="transform: rotate(${turns}turn); 
+              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+              transition: transform ${TRANSITION};"
+          >
             <path
               d=${triangle}
               stroke-linejoin="round"
@@ -123,11 +152,16 @@ export function extendWithRenderMarker(RtRingSvg) {
     } else {
       // render pointer markers
       const p1 = [MID_BOX, MID_BOX];
-      const p2 = getCoordFromDegrees(degrees, MID_BOX - width * 0.75, VIEW_BOX);
+      // const p2 = getCoordFromDegrees(0, MID_BOX - width * 0.75, VIEW_BOX);
+      const p2 = [MID_BOX, VIEW_BOX - width * 0.75];
       const strokeWidth = [2, 1.6, 1.4, 1.3, 1.2, 1.1][this.ring_size - 1];
       return {
         object: svg`
-          <g class=${className}>
+          <g class=${className}
+            style="transform: rotate(${degrees}deg); 
+              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+              transition: transform ${TRANSITION};"
+          >
             <line
               x1=${p1[0]} y1=${p1[1]}
               x2=${p2[0]} y2=${p2[1]}

--- a/src/svg/renderMarker.js
+++ b/src/svg/renderMarker.js
@@ -71,8 +71,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         return svg`
           <g class=${className} 
             style="transform: rotate(${turns}turn); 
-              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-              transition: transform ${TRANSITION};"
+              transform-origin: ${MID_BOX}px ${MID_BOX}px;"
           >
             <circle
               cx=${MID_BOX}
@@ -124,8 +123,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         object: svg`
           <g class=${className}
             style="transform: rotate(${turns}turn); 
-              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-              transition: transform ${TRANSITION};"
+              transform-origin: ${MID_BOX}px ${MID_BOX}px;"
           >
             <path
               d=${triangle}
@@ -137,8 +135,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         mask: svg`
           <g class=${className}
             style="transform: rotate(${turns}turn); 
-              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-              transition: transform ${TRANSITION};"
+              transform-origin: ${MID_BOX}px ${MID_BOX}px;"
           >
             <path
               d=${triangle}
@@ -159,8 +156,7 @@ export function extendWithRenderMarker(RtRingSvg) {
         object: svg`
           <g class=${className}
             style="transform: rotate(${degrees}deg); 
-              transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-              transition: transform ${TRANSITION};"
+              transform-origin: ${MID_BOX}px ${MID_BOX}px;"
           >
             <line
               x1=${p1[0]} y1=${p1[1]}

--- a/src/svg/renderMarker.js
+++ b/src/svg/renderMarker.js
@@ -1,6 +1,6 @@
 import { svg } from "lit";
-import { CM, IND, MID_BOX, RT, TRANSITION, VIEW_BOX } from "../const";
-import { clamp, deg2rad, getCoordFromDegrees } from "../helpers/utilities";
+import { CM, IND, MID_BOX, RT, VIEW_BOX } from "../const";
+import { clamp, deg2rad } from "../helpers/utilities";
 
 export function extendWithRenderMarker(RtRingSvg) {
   RtRingSvg.prototype.renderMarker = function (

--- a/src/svg/renderPointer.js
+++ b/src/svg/renderPointer.js
@@ -1,25 +1,26 @@
 import { svg } from "lit";
-import { MID_BOX, RT, VIEW_BOX } from "../const";
-import { getCoordFromDegrees } from "../helpers/utilities";
+import { MID_BOX, RT, TRANSITION, VIEW_BOX } from "../const";
 
 export function extendWithRenderPointer(RtRingSvg) {
   RtRingSvg.prototype.renderPointer = function (degrees) {
-    const startPoint = getCoordFromDegrees(
-      this.ring_type === RT.CLOSED ? degrees : (degrees + 180) % 360,
-      (0.15 * VIEW_BOX) / 2,
-      VIEW_BOX
-    );
-    const endPoint = getCoordFromDegrees(
-      this.ring_type !== RT.CLOSED ? degrees : (degrees + 180) % 360,
-      this._outerRadius - this._ringWidth / 2,
-      VIEW_BOX
-    );
+    degrees = this.ring_type.startsWith(RT.COMPASS)
+      ? (degrees + 180) % 360
+      : degrees;
+    const tail = [MID_BOX, MID_BOX - (0.15 * VIEW_BOX) / 2];
+    const point = [
+      MID_BOX,
+      MID_BOX + this._outerRadius - this._ringWidth / 2,
+    ];
     return {
       object: svg`
-        <g class="indicator">
+        <g class="indicator" 
+          style="transform: rotate(${degrees}deg); 
+            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
+            transition: transform ${TRANSITION};"
+        >
           <line class="pointer"
-            x1=${startPoint[0]} y1=${startPoint[1]}
-            x2=${endPoint[0]}   y2=${endPoint[1]}
+            x1=${tail[0]} y1=${tail[1]}
+            x2=${point[0]}   y2=${point[1]}
             stroke-width=${[5, 3, 2.5, 2.5, 2.3, 2.0][this.ring_size - 1]}
             stroke-linecap="round"
           />

--- a/src/svg/renderPointer.js
+++ b/src/svg/renderPointer.js
@@ -1,5 +1,5 @@
 import { svg } from "lit";
-import { MID_BOX, RT, TRANSITION, VIEW_BOX } from "../const";
+import { MID_BOX, RT, VIEW_BOX } from "../const";
 
 export function extendWithRenderPointer(RtRingSvg) {
   RtRingSvg.prototype.renderPointer = function (degrees) {
@@ -7,10 +7,8 @@ export function extendWithRenderPointer(RtRingSvg) {
       ? (degrees + 180) % 360
       : degrees;
     const tail = [MID_BOX, MID_BOX - (0.15 * VIEW_BOX) / 2];
-    const point = [
-      MID_BOX,
-      MID_BOX + this._outerRadius - this._ringWidth / 2,
-    ];
+    const point = [MID_BOX, MID_BOX + this._outerRadius - this._ringWidth / 2];
+    
     return {
       object: svg`
         <g class="indicator" 

--- a/src/svg/renderPointer.js
+++ b/src/svg/renderPointer.js
@@ -15,8 +15,7 @@ export function extendWithRenderPointer(RtRingSvg) {
       object: svg`
         <g class="indicator" 
           style="transform: rotate(${degrees}deg); 
-            transform-origin: ${MID_BOX}px ${MID_BOX}px; 
-            transition: transform ${TRANSITION};"
+            transform-origin: ${MID_BOX}px ${MID_BOX}px;"
         >
           <line class="pointer"
             x1=${tail[0]} y1=${tail[1]}

--- a/src/svg/renderRing.js
+++ b/src/svg/renderRing.js
@@ -84,6 +84,7 @@ export function extendWithRenderRings(RtRingSvg) {
             stroke-width=${width}
             stroke-opacity="1"
             stroke-linecap="round"
+            stroke-dasharray="0 10000"
             stroke-dashoffset="0"
             fill="transparent"
           />
@@ -103,7 +104,7 @@ export function extendWithRenderRings(RtRingSvg) {
   ) {
     self._lastRingLength = self._lastRingLength || 0;
     if (changedProperties.has("state") || changedProperties.has("ring_state")) {
-      // Wait for DOM update, then animate
+      // Wait for DOM to update so that we can access getTotalLength()
       requestAnimationFrame(() => {
         const animatedPath = self.shadowRoot?.querySelector(
           ".solid-ring-animated"

--- a/src/svg/renderRing.js
+++ b/src/svg/renderRing.js
@@ -1,6 +1,6 @@
-import { LitElement, svg } from "lit";
-import { MID_BOX, RT, TRANSITION, VIEW_BOX } from "../const";
-import { getRingPath, getRingPath2 } from "./getRingPath";
+import { svg } from "lit";
+import { VIEW_BOX } from "../const";
+import {  getRingPath } from "./getRingPath";
 
 export function extendWithRenderRings(RtRingSvg) {
   RtRingSvg.prototype.renderGradRing = function (
@@ -10,21 +10,27 @@ export function extendWithRenderRings(RtRingSvg) {
     cutOuts = []
   ) {
     const width = this._ringWidth;
-    const segment = getRingPath(startAngle, endAngle, this._outerRadius, width);
+    const segment = getRingPath(
+      startAngle,
+      endAngle,
+      this._outerRadius,
+      width
+    );
 
     const ringGradient = this._grad.getConicGradientCss(opacity);
 
-    const id = opacity.toString().replace(".", "");
     return {
       object: svg`
         <g class="ring-grad">
-          <clipPath id="ring-clip-${id}">
-            <path
+          <mask id="cut-outs-ring-grad">
+            <path               
+              stroke-width=${width}
+              stroke-opacity="1"
+              stroke-linecap="round"
+              fill="transparent" 
+              stroke="white" 
               d=${segment}
             />
-          </clipPath>
-          <mask id="cut-outs-ring-grad">
-            <rect width=${VIEW_BOX} height=${VIEW_BOX} fill="white" />
             <g fill="black" stroke="black" stroke-width="0">
               ${cutOuts}
             </g>
@@ -32,7 +38,6 @@ export function extendWithRenderRings(RtRingSvg) {
           <foreignObject
             x="0" y="0"
             width=${VIEW_BOX} height=${VIEW_BOX}
-            clip-path="url(#ring-clip-${id})"
             mask="url(#cut-outs-ring-grad)"
           >
             <div
@@ -53,14 +58,14 @@ export function extendWithRenderRings(RtRingSvg) {
   ) {
     const width = this._ringWidth;
     // render the actual solid ring (but which will be invisible)
-    const actualPath = getRingPath2(
+    const actualPath = getRingPath(
       startAngle,
       endAngle,
       this._outerRadius,
       width
     );
     // render the entire ring (which will be partially rendered using dasharray)
-    const animatedPath = getRingPath2(
+    const animatedPath = getRingPath(
       startAngle,
       359.9999 - startAngle,
       this._outerRadius,

--- a/src/svg/renderRing.js
+++ b/src/svg/renderRing.js
@@ -52,12 +52,14 @@ export function extendWithRenderRings(RtRingSvg) {
     cutOuts = []
   ) {
     const width = this._ringWidth;
+    // render the actual solid ring (but which will be invisible)
     const actualPath = getRingPath2(
       startAngle,
       endAngle,
       this._outerRadius,
       width
     );
+    // render the entire ring (which will be partially rendered using dasharray)
     const animatedPath = getRingPath2(
       startAngle,
       359.9999 - startAngle,
@@ -76,8 +78,6 @@ export function extendWithRenderRings(RtRingSvg) {
           </mask>
           <path 
             d=${animatedPath}
-            style="transition: stroke-dasharray ${TRANSITION}, 
-              stroke ${TRANSITION};"
             class="solid-ring-animated"
             mask="url(#cut-outs-ring-solid)"
             stroke=${this._grad.getSolidColour(rawValue)}
@@ -101,7 +101,6 @@ export function extendWithRenderRings(RtRingSvg) {
     changedProperties,
     self
   ) {
-    // Add lifecycle hook to handle animation on updates
     self._lastRingLength = self._lastRingLength || 0;
     if (changedProperties.has("state") || changedProperties.has("ring_state")) {
       // Wait for DOM update, then animate
@@ -113,7 +112,7 @@ export function extendWithRenderRings(RtRingSvg) {
         if (actualPath) {
           const length = actualPath.getTotalLength();
           if (length !== self._lastRingLength) {
-            animatedPath.style.strokeDasharray = `${length} 10000`; // Animate to visible
+            animatedPath.style.strokeDasharray = `${length} 10000`;
             self._lastRingLength = length;
           }
         }


### PR DESCRIPTION
Introduced animation of state transitions for indicators and markers. Respects system level "prefers reduced motion" setting.

Animation timing can be modified with `--rt-transition` CSS variable (which defaults to `0.75s ease-in-out`). Use `none` to deactivate animations. 

Required extensive refactoring of ring rendering and update handling. Obscure rendering error in Safari 16 on older devices, affecting transitions of the arc indicator. Rather than trying to fix, have just inhibited arc transitions on Safari <17. 